### PR TITLE
Implicitly track resources loaded in the resolver

### DIFF
--- a/controllers/client.go
+++ b/controllers/client.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/vmware-labs/reconciler-runtime/reconcilers"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TrackingClient(config reconcilers.Config) client.Client {
+	return &trackingClient{config}
+}
+
+type trackingClient struct {
+	reconcilers.Config
+}
+
+func (c *trackingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	return c.Config.TrackAndGet(ctx, key, obj)
+}

--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -74,7 +74,7 @@ func ResolveBindingSecret() reconcilers.SubReconciler {
 				Namespace:  resource.Namespace,
 				Name:       resource.Spec.Service.Name,
 			}
-			secretName, err := resolver.New(c).LookupBindingSecret(ctx, ref)
+			secretName, err := resolver.New(TrackingClient(c)).LookupBindingSecret(ctx, ref)
 			if err != nil {
 				if apierrs.IsNotFound(err) {
 					// leave Unknown, the provisioned service may be created shortly
@@ -120,7 +120,7 @@ func ResolveWorkloads() reconcilers.SubReconciler {
 				Namespace:  resource.Namespace,
 				Name:       resource.Spec.Workload.Name,
 			}
-			workloads, err := resolver.New(c).LookupWorkloads(ctx, ref, resource.Spec.Workload.Selector)
+			workloads, err := resolver.New(TrackingClient(c)).LookupWorkloads(ctx, ref, resource.Spec.Workload.Selector)
 			if err != nil {
 				if apierrs.IsNotFound(err) {
 					// leave Unknown, the workload may be created shortly
@@ -158,7 +158,7 @@ func ProjectBinding() reconcilers.SubReconciler {
 		SyncDuringFinalization: true,
 		Sync: func(ctx context.Context, resource *servicebindingv1beta1.ServiceBinding) error {
 			c := reconcilers.RetrieveConfigOrDie(ctx)
-			projector := projector.New(resolver.New(c))
+			projector := projector.New(resolver.New(TrackingClient(c)))
 
 			workloads := RetrieveWorkloads(ctx)
 			projectedWorkloads := make([]runtime.Object, len(workloads))

--- a/controllers/servicebinding_controller_test.go
+++ b/controllers/servicebinding_controller_test.go
@@ -76,6 +76,11 @@ func TestServiceBindingReconciler(t *testing.T) {
 			})
 		})
 
+	workloadMapping := dieservicebindingv1beta1.ClusterWorkloadResourceMappingBlank.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Name("deployments.apps")
+		})
+
 	workload := dieappsv1.DeploymentBlank.
 		DieStamp(func(r *appsv1.Deployment) {
 			r.APIVersion = "apps/v1"
@@ -164,6 +169,7 @@ func TestServiceBindingReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(projectedWorkload, serviceBinding, scheme),
+			rtesting.NewTrackRequest(workloadMapping, serviceBinding, scheme),
 		},
 	}, {
 		Name: "newly created",
@@ -174,6 +180,7 @@ func TestServiceBindingReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(projectedWorkload, serviceBinding, scheme),
+			rtesting.NewTrackRequest(workloadMapping, serviceBinding, scheme),
 		},
 		ExpectEvents: []rtesting.Event{
 			rtesting.NewEvent(serviceBinding, scheme, corev1.EventTypeNormal, "FinalizerPatched", "Patched finalizer %q", "servicebinding.io/finalizer"),
@@ -219,6 +226,7 @@ func TestServiceBindingReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(projectedWorkload, serviceBinding, scheme),
+			rtesting.NewTrackRequest(workloadMapping, serviceBinding, scheme),
 		},
 		ExpectEvents: []rtesting.Event{
 			rtesting.NewEvent(serviceBinding, scheme, corev1.EventTypeNormal, "Updated", "Updated Deployment %q", "my-workload"),
@@ -686,6 +694,11 @@ func TestProjectBinding(t *testing.T) {
 			})
 		})
 
+	workloadMapping := dieservicebindingv1beta1.ClusterWorkloadResourceMappingBlank.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Name("deployments.apps")
+		})
+
 	workload := dieappsv1.DeploymentBlank.
 		DieStamp(func(r *appsv1.Deployment) {
 			r.APIVersion = "apps/v1"
@@ -772,6 +785,9 @@ func TestProjectBinding(t *testing.T) {
 				projectedWorkload.DieReleaseUnstructured(),
 			},
 		},
+		ExpectTracks: []rtesting.TrackRequest{
+			rtesting.NewTrackRequest(workloadMapping, serviceBinding, scheme),
+		},
 	}, {
 		Name: "unproject terminating workload",
 		Resource: serviceBinding.
@@ -794,6 +810,9 @@ func TestProjectBinding(t *testing.T) {
 			controllers.ProjectedWorkloadsStashKey: []runtime.Object{
 				unprojectedWorkload,
 			},
+		},
+		ExpectTracks: []rtesting.TrackRequest{
+			rtesting.NewTrackRequest(workloadMapping, serviceBinding, scheme),
 		},
 	}}
 

--- a/resolver/cluster.go
+++ b/resolver/cluster.go
@@ -32,7 +32,7 @@ import (
 	servicebindingv1beta1 "github.com/servicebinding/runtime/apis/v1beta1"
 )
 
-// New creates a new resolver backed by a reconciler-runtime config
+// New creates a new resolver backed by a controller-runtime client
 func New(client client.Client) Resolver {
 	return &clusterResolver{
 		client: client,

--- a/resolver/cluster_test.go
+++ b/resolver/cluster_test.go
@@ -21,9 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/vmware-labs/reconciler-runtime/reconcilers"
 	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
-	"github.com/vmware-labs/reconciler-runtime/tracker"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -277,14 +275,11 @@ func TestClusterResolver_LookupMapping(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.TODO()
 
-			config := reconcilers.Config{
-				Client:  rtesting.NewFakeClient(scheme, c.givenObjects...),
-				Tracker: tracker.New(0),
-			}
-			restMapper := config.RESTMapper().(*meta.DefaultRESTMapper)
+			client := rtesting.NewFakeClient(scheme, c.givenObjects...)
+			restMapper := client.RESTMapper().(*meta.DefaultRESTMapper)
 			restMapper.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, meta.RESTScopeNamespace)
 			restMapper.Add(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}, meta.RESTScopeNamespace)
-			resolver := resolver.New(config)
+			resolver := resolver.New(client)
 
 			actual, err := resolver.LookupMapping(ctx, c.workload)
 
@@ -390,11 +385,8 @@ func TestClusterResolver_LookupBindingSecret(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.TODO()
 
-			config := reconcilers.Config{
-				Client:  rtesting.NewFakeClient(scheme, c.givenObjects...),
-				Tracker: tracker.New(0),
-			}
-			resolver := resolver.New(config)
+			client := rtesting.NewFakeClient(scheme, c.givenObjects...)
+			resolver := resolver.New(client)
 
 			actual, err := resolver.LookupBindingSecret(ctx, c.serviceRef)
 
@@ -693,11 +685,8 @@ func TestClusterResolver_LookupWorkloads(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.TODO()
 
-			config := reconcilers.Config{
-				Client:  rtesting.NewFakeClient(scheme, c.givenObjects...),
-				Tracker: tracker.New(0),
-			}
-			resolver := resolver.New(config)
+			client := rtesting.NewFakeClient(scheme, c.givenObjects...)
+			resolver := resolver.New(client)
 
 			actual, err := resolver.LookupWorkloads(ctx, c.serviceRef, c.selector)
 


### PR DESCRIPTION
We can implicitly track all resources loaded via .Get() in the resolver
without exposing the reconciler-runtime config as part of the contract.
This is done by wrapping the config object, intercepting the calls to
.Get() and then delegating those calls to .TrackAndGet().

This wrapper is only applied within the controller as the tracks are not
useful outside of that context.

Resolves #140 