### PR TITLE
Build multi-arch controller images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,7 @@ jobs:
 
         echo "##[group]Build"
           cat hack/boilerplate.yaml.txt > "${scratch}/config/servicebinding-runtime.yaml"
-          ${KO} resolve -f config/servicebinding-runtime.yaml >> "${scratch}/config/servicebinding-runtime.yaml"
+          ${KO} resolve --platform all -f config/servicebinding-runtime.yaml >> "${scratch}/config/servicebinding-runtime.yaml"
           ${KBLD} -f "${scratch}/config/servicebinding-runtime.yaml" --imgpkg-lock-output "${scratch}/.imgpkg/images.yml" > /dev/null
         echo "##[endgroup]"
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ YTT ?= go run -modfile hack/ytt/go.mod github.com/vmware-tanzu/carvel-ytt/cmd/yt
 KAPP_APP ?= servicebinding-runtime
 KAPP_APP_NAMESPACE ?= default
 
+KO_PLATFORMS ?= all
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
@@ -73,7 +75,7 @@ test: manifests generate fmt vet ## Run tests.
 
 .PHONY: deploy
 deploy: manifests ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(KAPP) deploy -a $(KAPP_APP) -n $(KAPP_APP_NAMESPACE) -c -f config/kapp -f <($(KO) resolve -f config/servicebinding-runtime.yaml)
+	$(KAPP) deploy -a $(KAPP_APP) -n $(KAPP_APP_NAMESPACE) -c -f config/kapp -f <($(KO) resolve --platform $(KO_PLATFORMS) -f config/servicebinding-runtime.yaml)
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
By default we build the controller for all architectured supported by
the default base image `gcr.io/distroless/static:nonroot`. Including:
- linux/arm64
- linux/arm
- linux/ppc64le
- linux/s390x
- linux/amd64

At development time, a subset can be built by setting KO_PLATFORMS:

```
KO_PLATFORMS=linux/amd64 make deploy
```

Resolves #150 

Signed-off-by: Scott Andrews <andrewssc@vmware.com>