### PR TITLE
Drop reinvocationPolicy from ValidatingWebhookConfiguration

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -108,5 +108,4 @@ webhooks:
       namespace: system
       path: /trigger
   failurePolicy: Ignore
-  reinvocationPolicy: Never
   sideEffects: None

--- a/config/servicebinding-runtime.yaml
+++ b/config/servicebinding-runtime.yaml
@@ -1043,7 +1043,6 @@ webhooks:
       values:
       - servicebinding-system
       - kube-system
-  reinvocationPolicy: Never
   sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
The reinvocationPolicy is only valid for MutatingWebhookConfigurations.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>