### PR TITLE
Test sample app in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -299,6 +299,16 @@ jobs:
           ${KAPP} deploy -a servicebinding-runtime -n apps --wait-timeout 5m -y \
             -f <(${KBLD} -f bundle/.imgpkg/images.yml -f bundle/config)
         echo "##[endgroup]"
+    - name: Test samples
+      run: |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        echo "##[group]Deploy spring-petclinic"
+          ${KAPP} deploy -a servicebinding-sample-spring-petclinic -n apps --wait-timeout 5m -y \
+            -f samples/spring-petclinic
+        echo "##[endgroup]"
 
     # TODO add acceptance tests
     
@@ -343,6 +353,9 @@ jobs:
         set -o nounset
         set -o pipefail
 
+        echo "##[group]Delete spring-petclinic"
+          ${KAPP} delete -a servicebinding-sample-spring-petclinic -n apps --wait-timeout 5m -y
+        echo "##[endgroup]"
         echo "##[group]Delete servicebinding-runtime"
           ${KAPP} delete -a servicebinding-runtime -n apps --wait-timeout 5m -y
         echo "##[endgroup]"

--- a/samples/spring-petclinic/kapp-config.yaml
+++ b/samples/spring-petclinic/kapp-config.yaml
@@ -1,0 +1,38 @@
+# Copyright 2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kapp-config
+  labels:
+    kapp.k14s.io/config: ""
+data:
+  config.yml: |
+    apiVersion: kapp.k14s.io/v1alpha1
+    kind: Config
+    waitRules:
+    - supportsObservedGeneration: true
+      conditionMatchers:
+      - type: ServiceAvailable
+        status: "True"
+        unblockChanges: true
+      - type: Ready
+        status: "False"
+        failure: true
+      - type: Ready
+        status: "True"
+        success: true
+      resourceMatchers:
+      - apiVersionKindMatcher: {apiVersion: servicebinding.io/v1beta1, kind: ServiceBinding}

--- a/samples/spring-petclinic/service-binding.yaml
+++ b/samples/spring-petclinic/service-binding.yaml
@@ -17,6 +17,12 @@ apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: spring-petclinic-db
+  annotations:
+    kapp.k14s.io/change-group: binding
+    kapp.k14s.io/change-rule.service: "upsert after upserting service"
+    kapp.k14s.io/change-rule.service-delete: "delete before deleting service"
+    kapp.k14s.io/change-rule.workload: "upsert before upserting workload"
+    kapp.k14s.io/change-rule.workload-delete: "delete after deleting workload"
 spec:
   # direct Secret reference is used for compatibility, but not recommended for dynamically provisioned services
   service:

--- a/samples/spring-petclinic/service.yaml
+++ b/samples/spring-petclinic/service.yaml
@@ -17,6 +17,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: spring-petclinic-db
+  annotations:
+    kapp.k14s.io/change-group: service
 type: servicebinding.io/mysql
 stringData:
   type: mysql
@@ -33,6 +35,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: spring-petclinic-db
+  annotations:
+    kapp.k14s.io/change-group: service
 spec:
   ports:
   - port: 3306
@@ -44,6 +48,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: spring-petclinic-db
+  annotations:
+    kapp.k14s.io/change-group: service
   labels:
     app: spring-petclinic-db
 spec:

--- a/samples/spring-petclinic/workload.yaml
+++ b/samples/spring-petclinic/workload.yaml
@@ -17,6 +17,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: spring-petclinic
+  annotations:
+    kapp.k14s.io/change-group: workload
 spec:
   ports:
   - port: 80
@@ -29,6 +31,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: spring-petclinic
+  annotations:
+    kapp.k14s.io/change-group: workload
   labels:
     app: spring-petclinic
 spec:
@@ -38,6 +42,9 @@ spec:
       app: spring-petclinic
   template:
     metadata:
+      annotations:
+        kapp.k14s.io/deploy-logs: "for-new"
+        kapp.k14s.io/deploy-logs-container-names: "workload"
       labels:
         app: spring-petclinic
     spec:


### PR DESCRIPTION
In addition to the conformance test suite, we should also start to test
our samples. This change updates the spring-petclinic sample to use kapp
to deploy and updates the sample readme to describe the benefits of kapp
and how we leverage them for the sample.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>