### PR TITLE
Bump github.com/vmware-labs/reconciler-runtime to 0.8.0

### DIFF
--- a/apis/v1alpha3/groupversion_info.go
+++ b/apis/v1alpha3/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha3 contains API Schema definitions for the  v1alpha3 API group
-//+kubebuilder:object:generate=true
-//+groupName=servicebinding.io
+// +kubebuilder:object:generate=true
+// +groupName=servicebinding.io
 package v1alpha3
 
 import (

--- a/apis/v1beta1/groupversion_info.go
+++ b/apis/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the servicebinding.io v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=servicebinding.io
+// +kubebuilder:object:generate=true
+// +groupName=servicebinding.io
 package v1beta1
 
 import (

--- a/apis/v1beta1/servicebinding_lifecycle.go
+++ b/apis/v1beta1/servicebinding_lifecycle.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the servicebinding.io v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=servicebinding.io
+// +kubebuilder:object:generate=true
+// +groupName=servicebinding.io
 package v1beta1
 
 import (

--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/vmware-labs/reconciler-runtime/apis"
 	"github.com/vmware-labs/reconciler-runtime/reconcilers"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -195,9 +194,6 @@ func PatchWorkloads() reconcilers.SubReconciler {
 		Type: &unstructured.Unstructured{},
 		MergeBeforeUpdate: func(current, desired *unstructured.Unstructured) {
 			current.SetUnstructuredContent(desired.UnstructuredContent())
-		},
-		SemanticEquals: func(a1, a2 *unstructured.Unstructured) bool {
-			return equality.Semantic.DeepEqual(a1, a2)
 		},
 	}
 

--- a/controllers/webhook_controller.go
+++ b/controllers/webhook_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/vmware-labs/reconciler-runtime/reconcilers"
 	"github.com/vmware-labs/reconciler-runtime/tracker"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -74,13 +73,6 @@ func AdmissionProjectorReconciler(c reconcilers.Config, name string, accessCheck
 			rules := RetrieveWebhookRules(ctx)
 			resource.Webhooks[0].Rules = rules
 			return resource, nil
-		},
-		SemanticEquals: func(a1, a2 *admissionregistrationv1.MutatingWebhookConfiguration) bool {
-			if a1 == nil || len(a1.Webhooks) != 1 || a2 == nil || len(a2.Webhooks) != 1 {
-				// the webhook config isn't in a form that we expect, ignore it
-				return true
-			}
-			return equality.Semantic.DeepEqual(a1.Webhooks[0].Rules, a2.Webhooks[0].Rules)
 		},
 		MergeBeforeUpdate: func(current, desired *admissionregistrationv1.MutatingWebhookConfiguration) {
 			if current == nil || len(current.Webhooks) != 1 || desired == nil || len(desired.Webhooks) != 1 {
@@ -194,13 +186,6 @@ func TriggerReconciler(c reconcilers.Config, name string, accessChecker rbac.Acc
 			rules := RetrieveWebhookRules(ctx)
 			resource.Webhooks[0].Rules = rules
 			return resource, nil
-		},
-		SemanticEquals: func(a1, a2 *admissionregistrationv1.ValidatingWebhookConfiguration) bool {
-			if a1 == nil || len(a1.Webhooks) != 1 || a2 == nil || len(a2.Webhooks) != 1 {
-				// the webhook config isn't in a form that we expect, ignore it
-				return true
-			}
-			return equality.Semantic.DeepEqual(a1.Webhooks[0].Rules, a2.Webhooks[0].Rules)
 		},
 		MergeBeforeUpdate: func(current, desired *admissionregistrationv1.ValidatingWebhookConfiguration) {
 			if current == nil || len(current.Webhooks) != 1 || desired == nil || len(desired.Webhooks) != 1 {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	dies.dev v0.5.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8
-	github.com/vmware-labs/reconciler-runtime v0.7.1
+	github.com/vmware-labs/reconciler-runtime v0.8.0
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	k8s.io/api v0.24.4
 	k8s.io/apimachinery v0.24.4

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/vmware-labs/reconciler-runtime v0.7.1 h1:CH7yzD2dQsCKFmICqXhmE9vS9B84ogY3W6tl6wJgJ9Y=
-github.com/vmware-labs/reconciler-runtime v0.7.1/go.mod h1:pNWkfKJzNJ1j2m6g3PeBIM9uy4KaUWNXYqAf6SqR+b4=
+github.com/vmware-labs/reconciler-runtime v0.8.0 h1:3ZhFw9SbRsKwNXnkNVqexv9o384QEfoWHLYAaJ+FzgA=
+github.com/vmware-labs/reconciler-runtime v0.8.0/go.mod h1:+Q4oBEd//FGjRBmt3m7gydDg7xqlxFJv9+Ik8oc4kzk=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Most of this diff is whitespace caused by reformating the test suites
from a list to a map. The new style improves code folding in editors.

It also takes advantage of new capabilities to streamline a couple
corner cases in the tests and removes code that is no longer required.

There are no semantic changes.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>