### PR TITLE
Update version of k8s v1.24 used in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,7 +160,7 @@ jobs:
         - 1.21.12
         - 1.22.9
         - 1.23.6
-        - 1.24.0
+        - 1.24.3
     env:
       REGISTRY_NAME: registry.local
       BUNDLE: registry.local/bundle


### PR DESCRIPTION
Since we defined our CI pipelines, kubernetes v1.24 has seen a few patch releases.  Update CI to use a more recent version.

Kubernetes v1.22 & v1.23 have also seen newer patch releases, and v1.25 was released recently.  However, corresponding `kindest/node` images have not been made yet, so we can't update those yet.


Signed-off-by: Andy Sadler <ansadler@redhat.com>