### PR TITLE
Bump go to 1.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - uses: actions/checkout@v3
     - name: Test
       run: make test
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - name: Generate certs
       run: |
         set -o errexit
@@ -168,7 +168,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - name: Install kind
       run: |
         cd $(mktemp -d -t kind.XXXX)
@@ -394,7 +394,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/servicebinding/runtime
 
-go 1.18
+go 1.19
 
 require (
 	dies.dev v0.5.0

--- a/hack/controller-gen/go.mod
+++ b/hack/controller-gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/servicebinding/runtime/hack/controller-gen
 
-go 1.18
+go 1.19
 
 require sigs.k8s.io/controller-tools v0.9.2
 

--- a/hack/diegen/go.mod
+++ b/hack/diegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/servicebinding/runtime/hack/controller-gen
 
-go 1.18
+go 1.19
 
 require dies.dev/diegen v0.5.0
 

--- a/hack/goimports/go.mod
+++ b/hack/goimports/go.mod
@@ -1,6 +1,6 @@
 module github.com/servicebinding/runtime/hack/goimports
 
-go 1.18
+go 1.19
 
 require golang.org/x/tools v0.1.12
 

--- a/hack/imgpkg/go.mod
+++ b/hack/imgpkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/servicebinding/runtime/hack/imgpkg
 
-go 1.18
+go 1.19
 
 require github.com/vmware-tanzu/carvel-imgpkg v0.31.0
 

--- a/hack/kapp/go.mod
+++ b/hack/kapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/servicebinding/runtime/hack/kapp
 
-go 1.18
+go 1.19
 
 require github.com/k14s/kapp v0.52.0
 

--- a/hack/kbld/go.mod
+++ b/hack/kbld/go.mod
@@ -1,6 +1,6 @@
 module github.com/servicebinding/runtime/hack/kbld
 
-go 1.18
+go 1.19
 
 require github.com/vmware-tanzu/carvel-kbld v0.34.0
 

--- a/hack/ko/go.mod
+++ b/hack/ko/go.mod
@@ -1,6 +1,6 @@
 module github.com/servicebinding/runtime/hack/ko
 
-go 1.18
+go 1.19
 
 require github.com/google/ko v0.11.2
 

--- a/hack/kustomize/go.mod
+++ b/hack/kustomize/go.mod
@@ -1,6 +1,6 @@
 module github.com/servicebinding/runtime/hack/kustomize
 
-go 1.18
+go 1.19
 
 require sigs.k8s.io/kustomize/kustomize/v4 v4.5.7
 


### PR DESCRIPTION
This is a prereq to embrace Kubernetes 1.25+ APIs.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>