### PR TITLE
Limit local and ci builds to arm64 and amd64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
     env:
       REGISTRY_NAME: registry.local
       KO_DOCKER_REPO: registry.local/servicebinding
+      KO_PLATFORMS: linux/amd64,linux/arm64
       BUNDLE: registry.local/servicebinding/bundle
     steps:
     - uses: actions/checkout@v3
@@ -110,6 +111,10 @@ jobs:
 
         # Make the $REGISTRY_NAME -> local-registry
         echo "$(hostname -I | cut -d' ' -f1) $REGISTRY_NAME" | sudo tee -a /etc/hosts
+    - name: Build all platforms for tags
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo "KO_PLATFORMS=all" >> $GITHUB_ENV
     - name: Build
       run: |
         set -o errexit
@@ -124,7 +129,7 @@ jobs:
 
         echo "##[group]Build"
           cat hack/boilerplate.yaml.txt > "${scratch}/config/servicebinding-runtime.yaml"
-          ${KO} resolve --platform all -f config/servicebinding-runtime.yaml >> "${scratch}/config/servicebinding-runtime.yaml"
+          ${KO} resolve --platform ${KO_PLATFORMS} -f config/servicebinding-runtime.yaml >> "${scratch}/config/servicebinding-runtime.yaml"
 
           cat hack/boilerplate.yaml.txt > "${scratch}/config/servicebinding-workloadresourcemappings.yaml"
           cat config/servicebinding-workloadresourcemappings.yaml >> "${scratch}/config/servicebinding-workloadresourcemappings.yaml"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ KUSTOMIZE ?= go run -modfile hack/kustomize/go.mod sigs.k8s.io/kustomize/kustomi
 KAPP_APP ?= servicebinding-runtime
 KAPP_APP_NAMESPACE ?= default
 
-KO_PLATFORMS ?= all
+KO_PLATFORMS ?= linux/arm64,linux/amd64
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.


### PR DESCRIPTION
We now limit the architectures to build images for to linux/arm64 and linux/amd64 for local and ci builds. All platforms are still built for tags.

The specific platforms to build can still be overridden using the KO_PLATFORMS envvar setting the value `all` or a comma separate list of `${GOOS}/${GOARCH}`. For example `linux/amd64,linux/arm64`.

This will speed up builds on machines with low CPU core counts (like GitHub Action runners).

Signed-off-by: Scott Andrews <andrewssc@vmware.com>