### PR TITLE
Unproject using the same mapping used to project the binding

### DIFF
--- a/projector/interface.go
+++ b/projector/interface.go
@@ -19,7 +19,9 @@ package projector
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	servicebindingv1beta1 "github.com/servicebinding/runtime/apis/v1beta1"
 )
@@ -32,8 +34,11 @@ type ServiceBindingProjector interface {
 }
 
 type MappingSource interface {
-	// LookupMapping the mapping template for the workload. Typically a ClusterWorkloadResourceMapping is defined for the workload's
-	// fully qualified resource `{resource}.{group}`. The workload's version is either directly matched, or the wildcard version `*`
-	// mapping template is returned. If no explicit mapping is found, a mapping appropriate for a PodSpecable resource may be used.
-	LookupMapping(ctx context.Context, workload runtime.Object) (*servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate, error)
+	// LookupRESTMapping returns the RESTMapping for the workload type. The rest mapping contains a GroupVersionResource which can
+	// be used to fetch the workload mapping.
+	LookupRESTMapping(ctx context.Context, obj runtime.Object) (*meta.RESTMapping, error)
+
+	// LookupWorkloadMapping the mapping template for the workload. Typically a ClusterWorkloadResourceMapping is defined for the
+	//  workload's fully qualified resource `{resource}.{group}`.
+	LookupWorkloadMapping(ctx context.Context, gvr schema.GroupVersionResource) (*servicebindingv1beta1.ClusterWorkloadResourceMappingSpec, error)
 }

--- a/projector/mapping.go
+++ b/projector/mapping.go
@@ -19,28 +19,68 @@ package projector
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	servicebindingv1beta1 "github.com/servicebinding/runtime/apis/v1beta1"
 )
 
-var _ MappingSource = (*staticMapping)(nil)
+// The workload's version is either directly matched, or the wildcard version `*`
+// mapping template is returned. If no explicit mapping is found, a mapping appropriate for a PodSpecable resource may be used.
+func MappingVersion(version string, mappings *servicebindingv1beta1.ClusterWorkloadResourceMappingSpec) *servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate {
+	wildcardMapping := servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate{Version: "*"}
+	var mapping *servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate
+	for _, v := range mappings.Versions {
+		switch v.Version {
+		case version:
+			mapping = &v
+		case "*":
+			wildcardMapping = v
+		}
+	}
+	if mapping == nil {
+		// use wildcard version by default
+		mapping = &wildcardMapping
+	}
 
-type staticMapping struct {
-	mapping *servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate
-}
-
-// NewStaticMapping returns a single ClusterWorkloadResourceMappingTemplate for each lookup. It is useful for
-// testing.
-func NewStaticMapping(mapping *servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate) MappingSource {
 	mapping = mapping.DeepCopy()
 	mapping.Default()
 
+	return mapping
+}
+
+var _ MappingSource = (*staticMapping)(nil)
+
+type staticMapping struct {
+	workloadMapping *servicebindingv1beta1.ClusterWorkloadResourceMappingSpec
+	restMapping     *meta.RESTMapping
+}
+
+// NewStaticMapping returns a single ClusterWorkloadResourceMappingSpec for each lookup. It is useful for
+// testing.
+func NewStaticMapping(wm *servicebindingv1beta1.ClusterWorkloadResourceMappingSpec, rm *meta.RESTMapping) MappingSource {
+	if len(wm.Versions) == 0 {
+		wm.Versions = []servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate{
+			{
+				Version: "*",
+			},
+		}
+	}
+	for i := range wm.Versions {
+		wm.Versions[i].Default()
+	}
+
 	return &staticMapping{
-		mapping: mapping,
+		workloadMapping: wm,
+		restMapping:     rm,
 	}
 }
 
-func (m *staticMapping) LookupMapping(ctx context.Context, workload runtime.Object) (*servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate, error) {
-	return m.mapping, nil
+func (m *staticMapping) LookupRESTMapping(ctx context.Context, obj runtime.Object) (*meta.RESTMapping, error) {
+	return m.restMapping, nil
+}
+
+func (m *staticMapping) LookupWorkloadMapping(ctx context.Context, gvr schema.GroupVersionResource) (*servicebindingv1beta1.ClusterWorkloadResourceMappingSpec, error) {
+	return m.workloadMapping, nil
 }

--- a/projector/metapodtemplate_test.go
+++ b/projector/metapodtemplate_test.go
@@ -33,8 +33,11 @@ import (
 )
 
 func TestNewMetaPodTemplate(t *testing.T) {
-	testAnnotations := map[string]string{
-		"key": "value",
+	testPodTemplateAnnotations := map[string]string{
+		"hello": "podtemplate",
+	}
+	testWorkloadAnnotations := map[string]string{
+		"hello": "workload",
 	}
 	testEnv := corev1.EnvVar{
 		Name:  "NAME",
@@ -64,10 +67,13 @@ func TestNewMetaPodTemplate(t *testing.T) {
 			name:    "podspecable",
 			mapping: &servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate{},
 			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: testWorkloadAnnotations,
+				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: testAnnotations,
+							Annotations: testPodTemplateAnnotations,
 						},
 						Spec: corev1.PodSpec{
 							InitContainers: []corev1.Container{
@@ -94,7 +100,8 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				},
 			},
 			expected: &metaPodTemplate{
-				Annotations: testAnnotations,
+				WorkloadAnnotations:    testWorkloadAnnotations,
+				PodTemplateAnnotations: testPodTemplateAnnotations,
 				Containers: []metaContainer{
 					{
 						Name:         pointer.String("init-hello"),
@@ -137,12 +144,15 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Volumes: ".spec.jobTemplate.spec.template.spec.volumes",
 			},
 			workload: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: testWorkloadAnnotations,
+				},
 				Spec: batchv1.CronJobSpec{
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: corev1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Annotations: testAnnotations,
+									Annotations: testPodTemplateAnnotations,
 								},
 								Spec: corev1.PodSpec{
 									InitContainers: []corev1.Container{
@@ -171,7 +181,8 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				},
 			},
 			expected: &metaPodTemplate{
-				Annotations: testAnnotations,
+				WorkloadAnnotations:    testWorkloadAnnotations,
+				PodTemplateAnnotations: testPodTemplateAnnotations,
 				Containers: []metaContainer{
 					{
 						Name:         pointer.String("init-hello"),
@@ -202,9 +213,10 @@ func TestNewMetaPodTemplate(t *testing.T) {
 			mapping:  &servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate{},
 			workload: &appsv1.Deployment{},
 			expected: &metaPodTemplate{
-				Annotations: map[string]string{},
-				Containers:  []metaContainer{},
-				Volumes:     []corev1.Volume{},
+				WorkloadAnnotations:    map[string]string{},
+				PodTemplateAnnotations: map[string]string{},
+				Containers:             []metaContainer{},
+				Volumes:                []corev1.Volume{},
 			},
 		},
 		{
@@ -222,7 +234,8 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				},
 			},
 			expected: &metaPodTemplate{
-				Annotations: map[string]string{},
+				WorkloadAnnotations:    map[string]string{},
+				PodTemplateAnnotations: map[string]string{},
 				Containers: []metaContainer{
 					{
 						Name:         pointer.String(""),
@@ -259,7 +272,8 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				},
 			},
 			expected: &metaPodTemplate{
-				Annotations: map[string]string{},
+				WorkloadAnnotations:    map[string]string{},
+				PodTemplateAnnotations: map[string]string{},
 				Containers: []metaContainer{
 					{
 						Name:         nil,
@@ -280,10 +294,13 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				},
 			},
 			workload: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: testWorkloadAnnotations,
+				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: testAnnotations,
+							Annotations: testPodTemplateAnnotations,
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
@@ -305,8 +322,9 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				},
 			},
 			expected: &metaPodTemplate{
-				Annotations: testAnnotations,
-				Containers:  []metaContainer{},
+				WorkloadAnnotations:    testWorkloadAnnotations,
+				PodTemplateAnnotations: testPodTemplateAnnotations,
+				Containers:             []metaContainer{},
 				Volumes: []corev1.Volume{
 					testVolume,
 				},
@@ -330,7 +348,7 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: testAnnotations,
+							Annotations: testPodTemplateAnnotations,
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
@@ -348,7 +366,8 @@ func TestNewMetaPodTemplate(t *testing.T) {
 				},
 			},
 			expected: &metaPodTemplate{
-				Annotations: map[string]string{},
+				WorkloadAnnotations:    map[string]string{},
+				PodTemplateAnnotations: map[string]string{},
 				Containers: []metaContainer{
 					{
 						Name:         pointer.String(""),
@@ -403,8 +422,11 @@ func TestNewMetaPodTemplate(t *testing.T) {
 }
 
 func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
-	testAnnotations := map[string]string{
-		"key": "value",
+	testPodTemplateAnnotations := map[string]string{
+		"hello": "podtemplate",
+	}
+	testWorkloadAnnotations := map[string]string{
+		"hello": "workload",
 	}
 	testEnv := corev1.EnvVar{
 		Name:  "NAME",
@@ -435,7 +457,8 @@ func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
 			name:    "podspecable",
 			mapping: &servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate{},
 			metadata: metaPodTemplate{
-				Annotations: testAnnotations,
+				WorkloadAnnotations:    testWorkloadAnnotations,
+				PodTemplateAnnotations: testPodTemplateAnnotations,
 				Containers: []metaContainer{
 					{
 						Name:         pointer.String("init-hello"),
@@ -477,10 +500,13 @@ func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
 				},
 			},
 			expected: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: testWorkloadAnnotations,
+				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: testAnnotations,
+							Annotations: testPodTemplateAnnotations,
 						},
 						Spec: corev1.PodSpec{
 							InitContainers: []corev1.Container{
@@ -530,7 +556,8 @@ func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
 				Volumes: ".spec.jobTemplate.spec.template.spec.volumes",
 			},
 			metadata: metaPodTemplate{
-				Annotations: testAnnotations,
+				WorkloadAnnotations:    testWorkloadAnnotations,
+				PodTemplateAnnotations: testPodTemplateAnnotations,
 				Containers: []metaContainer{
 					{
 						Name:         pointer.String("init-hello"),
@@ -576,13 +603,15 @@ func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
 				},
 			},
 			expected: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: testWorkloadAnnotations,
+				},
 				Spec: batchv1.CronJobSpec{
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
-
 							Template: corev1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Annotations: testAnnotations,
+									Annotations: testPodTemplateAnnotations,
 								},
 								Spec: corev1.PodSpec{
 									InitContainers: []corev1.Container{
@@ -621,12 +650,16 @@ func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
 			name:    "no containers",
 			mapping: &servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate{},
 			metadata: metaPodTemplate{
-				Annotations: map[string]string{},
-				Containers:  []metaContainer{},
-				Volumes:     []corev1.Volume{},
+				WorkloadAnnotations:    map[string]string{},
+				PodTemplateAnnotations: map[string]string{},
+				Containers:             []metaContainer{},
+				Volumes:                []corev1.Volume{},
 			},
 			workload: &appsv1.Deployment{},
 			expected: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -643,7 +676,8 @@ func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
 			name:    "empty container",
 			mapping: &servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate{},
 			metadata: metaPodTemplate{
-				Annotations: map[string]string{},
+				WorkloadAnnotations:    map[string]string{},
+				PodTemplateAnnotations: map[string]string{},
 				Containers: []metaContainer{
 					{
 						Name:         pointer.String(""),
@@ -665,6 +699,9 @@ func TestMetaPodTemplate_WriteToWorkload(t *testing.T) {
 				},
 			},
 			expected: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{

--- a/resolver/interface.go
+++ b/resolver/interface.go
@@ -20,17 +20,22 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	servicebindingv1beta1 "github.com/servicebinding/runtime/apis/v1beta1"
 )
 
 type Resolver interface {
-	// LookupMapping returns the mapping template for the workload. Typically a ClusterWorkloadResourceMapping is defined for the workload's
-	// fully qualified resource `{resource}.{group}`. The workload's version is either directly matched, or the wildcard version `*`
-	// mapping template is returned. If no explicit mapping is found, a mapping appropriate for a PodSpecable resource may be used.
-	LookupMapping(ctx context.Context, workload runtime.Object) (*servicebindingv1beta1.ClusterWorkloadResourceMappingTemplate, error)
+	// LookupRESTMapping returns the RESTMapping for the workload type. The rest mapping contains a GroupVersionResource which can
+	// be used to fetch the workload mapping.
+	LookupRESTMapping(ctx context.Context, obj runtime.Object) (*meta.RESTMapping, error)
+
+	// LookupWorkloadMapping the mapping template for the workload. Typically a ClusterWorkloadResourceMapping is defined for the
+	//  workload's fully qualified resource `{resource}.{group}`.
+	LookupWorkloadMapping(ctx context.Context, gvr schema.GroupVersionResource) (*servicebindingv1beta1.ClusterWorkloadResourceMappingSpec, error)
 
 	// LookupBindingSecret returns the binding secret name exposed by the service following the Provisioned Service duck-type
 	// (`.status.binding.name`). If a direction binding is used (where the referenced service is itself a Secret) the referenced Secret is


### PR DESCRIPTION
From the spec:

> When a service binding projection is removed, the controller MUST use
> the same mappings from the projection creation. After a
> ClusterWorkloadResourceMapping resource is modified, each binding
> targeting the mapped workload type MUST be removed, then reattempted
> with the latest mapping.

We now stash the mapping used to project the binding on the workload as an annotation. When unprojecting that same binding, we use the stashed mapping to unproject the binding. If updating an existing binding, the stashed mapping is used to cleanup existing state before the updated mapping is used to re-project the binding into the workload.

Resolves #138