### PR TITLE
Default KO_PLATFORMS to only the current arch when kind is the target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,12 @@ KUSTOMIZE ?= go run -modfile hack/kustomize/go.mod sigs.k8s.io/kustomize/kustomi
 KAPP_APP ?= servicebinding-runtime
 KAPP_APP_NAMESPACE ?= default
 
+ifeq (${KO_DOCKER_REPO},kind.local)
+# kind isn't multi-arch aware, default to the current arch
+KO_PLATFORMS ?= linux/$(shell go env GOARCH)
+else
 KO_PLATFORMS ?= linux/arm64,linux/amd64
+endif
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.


### PR DESCRIPTION
ko has special behavior for a `KO_DOCKER_REPO` value of `kind.local`, it will load the images directly into the daemon rather than a registry. Kind clusters do not support multi-arch images, we should assume by default that the kind cluster is running on the same arch as the host.

A user may continue to override the default by setting `KO_PLATFORMS` with the value they want to use at runtime.