### PR TITLE
ci: upload test results as an artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,18 +159,25 @@ jobs:
       matrix:
         include:
         - node: kindest/node:v1.21.14@sha256:220cfafdf6e3915fbce50e13d1655425558cb98872c53f802605aa2fb2d569cf
+          version: v1.21.14
           os: ubuntu-latest
         - node: kindest/node:v1.22.17@sha256:9af784f45a584f6b28bce2af84c494d947a05bd709151466489008f80a9ce9d5
+          version: v1.22.17
           os: ubuntu-latest
         - node: kindest/node:v1.23.17@sha256:f77f8cf0b30430ca4128cc7cfafece0c274a118cd0cdb251049664ace0dee4ff
+          version: v1.23.17
           os: ubuntu-latest
         - node: kindest/node:v1.24.13@sha256:cea86276e698af043af20143f4bf0509e730ec34ed3b7fa790cc0bea091bc5dd
+          version: v1.24.13
           os: ubuntu-latest
         - node: kindest/node:v1.25.9@sha256:c08d6c52820aa42e533b70bce0c2901183326d86dcdcbedecc9343681db45161
+          version: v1.25.9
           os: ubuntu-latest
         - node: kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e
+          version: v1.26.4
           os: ubuntu-latest
         - node: kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b
+          version: v1.27.1
           os: ubuntu-latest
     env:
       REGISTRY_NAME: registry.local
@@ -359,6 +366,12 @@ jobs:
         set -o nounset
         set +o pipefail
 
+        if [ -e conformance-tests/test-output/results/failing_scenarios.txt] ; then
+          echo "##[group]failing conformance tests"
+            cat conformance-tests/test-output/results/failing_scenarios.txt
+          echo "##[endgroup]"
+        fi
+
         echo "##[group]kubectl get clusterworkloadresourcemappings.servicebinding.io"
           kubectl get clusterworkloadresourcemappings.servicebinding.io
         echo "##[endgroup]"
@@ -394,6 +407,12 @@ jobs:
         echo "##[endgroup]"
       if: always()
       continue-on-error: true
+    - name: Save test results
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: acceptance-test-results-${{ matrix.version }}
+        path: conformance-tests/test-output/results
     - name: Delete Gracefully
       run: |
         set -o errexit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -366,7 +366,7 @@ jobs:
         set -o nounset
         set +o pipefail
 
-        if [ -e conformance-tests/test-output/results/failing_scenarios.txt] ; then
+        if [ -e conformance-tests/test-output/results/failing_scenarios.txt ] ; then
           echo "##[group]failing conformance tests"
             cat conformance-tests/test-output/results/failing_scenarios.txt
           echo "##[endgroup]"


### PR DESCRIPTION
Since we run tests in parallel, behavex doesn't output a lot to the console.  To retain some sense of ability to debug testing failures in CI, we should upload the output of behavex as an artifact to be inspected.