### PR TITLE
Add lifecycle hooks

### DIFF
--- a/controllers/servicebinding_controller_test.go
+++ b/controllers/servicebinding_controller_test.go
@@ -46,6 +46,7 @@ import (
 	servicebindingv1beta1 "github.com/servicebinding/runtime/apis/v1beta1"
 	"github.com/servicebinding/runtime/controllers"
 	dieservicebindingv1beta1 "github.com/servicebinding/runtime/dies/v1beta1"
+	"github.com/servicebinding/runtime/lifecycle"
 )
 
 func TestServiceBindingReconciler(t *testing.T) {
@@ -304,7 +305,7 @@ func TestServiceBindingReconciler(t *testing.T) {
 	rts.Run(t, scheme, func(t *testing.T, tc *rtesting.ReconcilerTestCase, c reconcilers.Config) reconcile.Reconciler {
 		restMapper := c.RESTMapper().(*meta.DefaultRESTMapper)
 		restMapper.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, meta.RESTScopeNamespace)
-		return controllers.ServiceBindingReconciler(c)
+		return controllers.ServiceBindingReconciler(c, lifecycle.ServiceBindingHooks{})
 	})
 }
 
@@ -528,7 +529,7 @@ func TestResolveBindingSecret(t *testing.T) {
 	}
 
 	rts.Run(t, scheme, func(t *testing.T, tc *rtesting.SubReconcilerTestCase[*servicebindingv1beta1.ServiceBinding], c reconcilers.Config) reconcilers.SubReconciler[*servicebindingv1beta1.ServiceBinding] {
-		return controllers.ResolveBindingSecret()
+		return controllers.ResolveBindingSecret(lifecycle.ServiceBindingHooks{})
 	})
 }
 
@@ -801,7 +802,7 @@ func TestResolveWorkload(t *testing.T) {
 	}
 
 	rts.Run(t, scheme, func(t *testing.T, tc *rtesting.SubReconcilerTestCase[*servicebindingv1beta1.ServiceBinding], c reconcilers.Config) reconcilers.SubReconciler[*servicebindingv1beta1.ServiceBinding] {
-		return controllers.ResolveWorkloads()
+		return controllers.ResolveWorkloads(lifecycle.ServiceBindingHooks{})
 	})
 }
 
@@ -972,7 +973,7 @@ func TestProjectBinding(t *testing.T) {
 	rts.Run(t, scheme, func(t *testing.T, tc *rtesting.SubReconcilerTestCase[*servicebindingv1beta1.ServiceBinding], c reconcilers.Config) reconcilers.SubReconciler[*servicebindingv1beta1.ServiceBinding] {
 		restMapper := c.RESTMapper().(*meta.DefaultRESTMapper)
 		restMapper.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, meta.RESTScopeNamespace)
-		return controllers.ProjectBinding()
+		return controllers.ProjectBinding(lifecycle.ServiceBindingHooks{})
 	})
 }
 

--- a/controllers/webhook_controller_test.go
+++ b/controllers/webhook_controller_test.go
@@ -55,6 +55,7 @@ import (
 	servicebindingv1beta1 "github.com/servicebinding/runtime/apis/v1beta1"
 	"github.com/servicebinding/runtime/controllers"
 	dieservicebindingv1beta1 "github.com/servicebinding/runtime/dies/v1beta1"
+	"github.com/servicebinding/runtime/lifecycle"
 	"github.com/servicebinding/runtime/rbac"
 )
 
@@ -519,7 +520,7 @@ func TestAdmissionProjectorWebhook(t *testing.T) {
 	wts.Run(t, scheme, func(t *testing.T, tc *rtesting.AdmissionWebhookTestCase, c reconcilers.Config) *admission.Webhook {
 		restMapper := c.RESTMapper().(*meta.DefaultRESTMapper)
 		restMapper.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, meta.RESTScopeNamespace)
-		return controllers.AdmissionProjectorWebhook(c).Build()
+		return controllers.AdmissionProjectorWebhook(c, lifecycle.ServiceBindingHooks{}).Build()
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	dies.dev v0.9.0
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.5.9
+	github.com/stretchr/testify v1.8.2
 	github.com/vmware-labs/reconciler-runtime v0.15.0
 	gomodules.xyz/jsonpatch/v2 v2.4.0
 	k8s.io/api v0.28.2
@@ -46,11 +47,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.25.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -112,6 +113,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/vmware-labs/reconciler-runtime v0.15.0 h1:bALsVuM8rIRozcs+gnpVvf9imUSw36q4tX72jHpQE0s=
 github.com/vmware-labs/reconciler-runtime v0.15.0/go.mod h1:y0JbNaM0BHlH6yBkIyGmOs/VsIZbKbTFzR178zoOowE=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/lifecycle/hooks.go
+++ b/lifecycle/hooks.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	servicebindingv1beta1 "github.com/servicebinding/runtime/apis/v1beta1"
+	"github.com/servicebinding/runtime/projector"
+	"github.com/servicebinding/runtime/resolver"
+)
+
+type ServiceBindingHooks struct {
+	// ResolverFactory returns a resolver which is used to lookup binding
+	// related values.
+	//
+	// +optional
+	ResolverFactory func(client.Client) resolver.Resolver
+
+	// ProjectorFactory returns a projector which is used to bind/unbind the
+	// service to/from the workload.
+	//
+	// +optional
+	ProjectorFactory func(projector.MappingSource) projector.ServiceBindingProjector
+
+	// ServiceBindingPreProjection can be used to alter the resolved
+	// ServiceBinding before the projection.
+	//
+	// +optional
+	ServiceBindingPreProjection func(ctx context.Context, binding *servicebindingv1beta1.ServiceBinding) error
+
+	// ServiceBindingPostProjection can be used to alter the projected
+	// ServiceBinding before mutations are persisted.
+	//
+	// +optional
+	ServiceBindingPostProjection func(ctx context.Context, binding *servicebindingv1beta1.ServiceBinding) error
+
+	// WorkloadPreProjection can be used to alter the resolved workload before
+	// the projection.
+	//
+	// +optional
+	WorkloadPreProjection func(ctx context.Context, workload runtime.Object) error
+
+	// WorkloadPostProjection can be used to alter the projected workload
+	// before mutations are persisted.
+	//
+	// +optional
+	WorkloadPostProjection func(ctx context.Context, workload runtime.Object) error
+}
+
+func (h *ServiceBindingHooks) GetResolver(c client.Client) resolver.Resolver {
+	if h.ResolverFactory == nil {
+		return resolver.New(c)
+	}
+	return h.ResolverFactory(c)
+}
+
+func (h *ServiceBindingHooks) GetProjector(r projector.MappingSource) projector.ServiceBindingProjector {
+	if h.ProjectorFactory == nil {
+		return projector.New(r)
+	}
+	return h.ProjectorFactory(r)
+}

--- a/lifecycle/hooks_test.go
+++ b/lifecycle/hooks_test.go
@@ -1,0 +1,323 @@
+/*
+Copyright 2023 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	dieappsv1 "dies.dev/apis/apps/v1"
+	diecorev1 "dies.dev/apis/core/v1"
+	diemetav1 "dies.dev/apis/meta/v1"
+	"github.com/stretchr/testify/mock"
+	"github.com/vmware-labs/reconciler-runtime/reconcilers"
+	rtesting "github.com/vmware-labs/reconciler-runtime/testing"
+	"github.com/vmware-labs/reconciler-runtime/tracker"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	servicebindingv1beta1 "github.com/servicebinding/runtime/apis/v1beta1"
+	"github.com/servicebinding/runtime/controllers"
+	dieservicebindingv1beta1 "github.com/servicebinding/runtime/dies/v1beta1"
+	"github.com/servicebinding/runtime/lifecycle"
+	"github.com/servicebinding/runtime/projector"
+	"github.com/servicebinding/runtime/resolver"
+)
+
+func TestServiceBindingHooks(t *testing.T) {
+	namespace := "test-namespace"
+	name := "my-binding"
+	secretName := "my-secret"
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(servicebindingv1beta1.AddToScheme(scheme))
+
+	serviceBinding := dieservicebindingv1beta1.ServiceBindingBlank.
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(namespace)
+			d.Name(name)
+			d.Finalizers("servicebinding.io/finalizer")
+			d.UID(uuid.NewUUID())
+		}).
+		SpecDie(func(d *dieservicebindingv1beta1.ServiceBindingSpecDie) {
+			d.ServiceDie(func(d *dieservicebindingv1beta1.ServiceBindingServiceReferenceDie) {
+				d.APIVersion("v1")
+				d.Kind("Secret")
+				d.Name(secretName)
+			})
+		}).
+		StatusDie(func(d *dieservicebindingv1beta1.ServiceBindingStatusDie) {
+			d.BindingDie(func(d *dieservicebindingv1beta1.ServiceBindingSecretReferenceDie) {
+				d.Name(secretName)
+			})
+			d.ConditionsDie(
+				dieservicebindingv1beta1.ServiceBindingConditionReady.True().Reason("ServiceBound"),
+				dieservicebindingv1beta1.ServiceBindingConditionServiceAvailable.True().Reason("ResolvedBindingSecret"),
+				dieservicebindingv1beta1.ServiceBindingConditionWorkloadProjected.True().Reason("ResolvedBindingSecret"),
+			)
+		})
+	serviceBindingByName := serviceBinding.
+		SpecDie(func(d *dieservicebindingv1beta1.ServiceBindingSpecDie) {
+			d.WorkloadDie(func(d *dieservicebindingv1beta1.ServiceBindingWorkloadReferenceDie) {
+				d.APIVersion("apps/v1")
+				d.Kind("Deployment")
+				d.Name(name)
+			})
+		})
+	serviceBindingBySelector := serviceBinding.
+		SpecDie(func(d *dieservicebindingv1beta1.ServiceBindingSpecDie) {
+			d.WorkloadDie(func(d *dieservicebindingv1beta1.ServiceBindingWorkloadReferenceDie) {
+				d.APIVersion("apps/v1")
+				d.Kind("Deployment")
+				d.SelectorDie(func(d *diemetav1.LabelSelectorDie) {
+					d.AddMatchLabel("test.servicebinding.io", "workload")
+				})
+			})
+		})
+
+	workload := dieappsv1.DeploymentBlank.
+		APIVersion("apps/v1").
+		Kind("Deployment").
+		MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+			d.Namespace(namespace)
+			d.Name(name)
+			d.UID(uuid.NewUUID())
+		}).
+		SpecDie(func(d *dieappsv1.DeploymentSpecDie) {
+			d.TemplateDie(func(d *diecorev1.PodTemplateSpecDie) {
+				d.SpecDie(func(d *diecorev1.PodSpecDie) {
+					d.ContainerDie("workload", func(d *diecorev1.ContainerDie) {
+						d.EnvDie("SERVICE_BINDING_ROOT", func(d *diecorev1.EnvVarDie) {
+							d.Value("/bindings")
+						})
+					})
+				})
+			})
+		})
+
+	anyContext := mock.MatchedBy(func(arg interface{}) bool {
+		_, ok := arg.(context.Context)
+		return ok
+	})
+	matchObj := func(expected client.Object) interface{} {
+		return mock.MatchedBy(func(actual client.Object) bool {
+			return expected.GetObjectKind().GroupVersionKind() == actual.GetObjectKind().GroupVersionKind() &&
+				expected.GetNamespace() == actual.GetNamespace() &&
+				expected.GetName() == actual.GetName() &&
+				expected.GetUID() == actual.GetUID()
+		})
+	}
+
+	t.Run("Controller", func(t *testing.T) {
+		workload1 := workload.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Name(fmt.Sprintf("%s-1", workload.GetName()))
+				d.UID(uuid.NewUUID())
+				d.AddLabel("test.servicebinding.io", "workload")
+			})
+		workload2 := workload.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Name(fmt.Sprintf("%s-2", workload.GetName()))
+				d.UID(uuid.NewUUID())
+				d.AddLabel("test.servicebinding.io", "workload")
+			})
+
+		rts := rtesting.SubReconcilerTests[*servicebindingv1beta1.ServiceBinding]{
+			"controller binding by name": {
+				Metadata: map[string]interface{}{
+					"HooksExpectations": func(m *mock.Mock) {
+						m.On("ServiceBindingPreProjection", 1, anyContext, matchObj(serviceBinding.DieReleasePtr())).Return(nil).Once()
+						m.On("WorkloadPreProjection", 2, anyContext, matchObj(workload.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("Projector.Project", 3, anyContext, matchObj(serviceBinding.DieReleasePtr()), matchObj(workload.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("WorkloadPostProjection", 4, anyContext, matchObj(workload.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("ServiceBindingPostProjection", 5, anyContext, matchObj(serviceBinding.DieReleasePtr())).Return(nil).Once()
+					},
+				},
+				CleanUp: func(t *testing.T, ctx context.Context, tc *rtesting.SubReconcilerTestCase[*servicebindingv1beta1.ServiceBinding]) error {
+					m := tc.Metadata["HooksMock"].(*mock.Mock)
+					m.AssertExpectations(t)
+					return nil
+				},
+				Resource: serviceBindingByName.DieReleasePtr(),
+				GivenObjects: []client.Object{
+					workload.DieReleasePtr(),
+				},
+				ExpectTracks: []rtesting.TrackRequest{
+					rtesting.NewTrackRequest(workload, serviceBinding, scheme),
+				},
+			},
+			"controller binding by selector": {
+				Metadata: map[string]interface{}{
+					"HooksExpectations": func(m *mock.Mock) {
+						m.On("ServiceBindingPreProjection", 1, anyContext, matchObj(serviceBinding.DieReleasePtr())).Return(nil).Once()
+						m.On("WorkloadPreProjection", 2, anyContext, matchObj(workload1.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("Projector.Project", 3, anyContext, matchObj(serviceBinding.DieReleasePtr()), matchObj(workload1.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("WorkloadPostProjection", 4, anyContext, matchObj(workload1.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("WorkloadPreProjection", 5, anyContext, matchObj(workload2.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("Projector.Project", 6, anyContext, matchObj(serviceBinding.DieReleasePtr()), matchObj(workload2.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("WorkloadPostProjection", 7, anyContext, matchObj(workload2.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("ServiceBindingPostProjection", 8, anyContext, matchObj(serviceBinding.DieReleasePtr())).Return(nil).Once()
+					},
+				},
+				CleanUp: func(t *testing.T, ctx context.Context, tc *rtesting.SubReconcilerTestCase[*servicebindingv1beta1.ServiceBinding]) error {
+					m := tc.Metadata["HooksMock"].(*mock.Mock)
+					m.AssertExpectations(t)
+					return nil
+				},
+				Resource: serviceBindingBySelector.DieReleasePtr(),
+				GivenObjects: []client.Object{
+					workload1.DieReleasePtr(),
+					workload2.DieReleasePtr(),
+				},
+				ExpectTracks: []rtesting.TrackRequest{
+					{
+						Tracker: types.NamespacedName{Namespace: namespace, Name: name},
+						TrackedReference: tracker.Reference{
+							APIGroup:  "apps",
+							Kind:      "Deployment",
+							Namespace: namespace,
+							Selector: labels.SelectorFromSet(labels.Set{
+								"test.servicebinding.io": "workload",
+							}),
+						},
+					},
+				},
+			},
+		}
+
+		rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase[*servicebindingv1beta1.ServiceBinding], c reconcilers.Config) reconcilers.SubReconciler[*servicebindingv1beta1.ServiceBinding] {
+			restMapper := c.RESTMapper().(*meta.DefaultRESTMapper)
+			restMapper.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, meta.RESTScopeNamespace)
+			hooks, m := makeHooks()
+			rtc.Metadata["HooksMock"] = m
+			rtc.Metadata["HooksExpectations"].(func(*mock.Mock))(m)
+			return controllers.ServiceBindingReconciler(c, hooks).Reconciler
+		})
+	})
+
+	t.Run("Webhook", func(t *testing.T) {
+		serviceBinding1 := serviceBindingByName.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Name(fmt.Sprintf("%s-1", serviceBinding.GetName()))
+				d.UID(uuid.NewUUID())
+			})
+		serviceBinding2 := serviceBindingByName.
+			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+				d.Name(fmt.Sprintf("%s-2", serviceBinding.GetName()))
+				d.UID(uuid.NewUUID())
+			})
+
+		addWorkloadRefIndex := func(cb *fake.ClientBuilder) *fake.ClientBuilder {
+			return cb.WithIndex(&servicebindingv1beta1.ServiceBinding{}, controllers.WorkloadRefIndexKey, controllers.WorkloadRefIndexFunc)
+		}
+
+		rts := rtesting.SubReconcilerTests[*unstructured.Unstructured]{
+			"webhook": {
+				Metadata: map[string]interface{}{
+					"HooksExpectations": func(m *mock.Mock) {
+						m.On("WorkloadPreProjection", 1, anyContext, matchObj(workload.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("ServiceBindingPreProjection", 2, anyContext, matchObj(serviceBinding1.DieReleasePtr())).Return(nil).Once()
+						m.On("Projector.Project", 3, anyContext, matchObj(serviceBinding1.DieReleasePtr()), matchObj(workload.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("ServiceBindingPostProjection", 4, anyContext, matchObj(serviceBinding1.DieReleasePtr())).Return(nil).Once()
+						m.On("ServiceBindingPreProjection", 5, anyContext, matchObj(serviceBinding2.DieReleasePtr())).Return(nil).Once()
+						m.On("Projector.Project", 6, anyContext, matchObj(serviceBinding2.DieReleasePtr()), matchObj(workload.DieReleaseUnstructured())).Return(nil).Once()
+						m.On("ServiceBindingPostProjection", 7, anyContext, matchObj(serviceBinding2.DieReleasePtr())).Return(nil).Once()
+						m.On("WorkloadPostProjection", 8, anyContext, matchObj(workload.DieReleaseUnstructured())).Return(nil).Once()
+					},
+				},
+				CleanUp: func(t *testing.T, ctx context.Context, tc *rtesting.SubReconcilerTestCase[*unstructured.Unstructured]) error {
+					m := tc.Metadata["HooksMock"].(*mock.Mock)
+					m.AssertExpectations(t)
+					return nil
+				},
+				WithClientBuilder: addWorkloadRefIndex,
+				Resource:          workload.DieReleaseUnstructured(),
+				GivenObjects: []client.Object{
+					serviceBinding1.DieReleasePtr(),
+					serviceBinding2.DieReleasePtr(),
+				},
+			},
+		}
+
+		rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase[*unstructured.Unstructured], c reconcilers.Config) reconcilers.SubReconciler[*unstructured.Unstructured] {
+			restMapper := c.RESTMapper().(*meta.DefaultRESTMapper)
+			restMapper.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, meta.RESTScopeNamespace)
+			hooks, m := makeHooks()
+			rtc.Metadata["HooksMock"] = m
+			rtc.Metadata["HooksExpectations"].(func(*mock.Mock))(m)
+			return controllers.AdmissionProjectorWebhook(c, hooks).Reconciler
+		})
+	})
+}
+
+type mockProjector struct {
+	m *mock.Mock
+	i *int
+}
+
+func (p *mockProjector) Project(ctx context.Context, binding *servicebindingv1beta1.ServiceBinding, workload runtime.Object) error {
+	*p.i = *p.i + 1
+	return p.m.MethodCalled("Projector.Project", *p.i, ctx, binding, workload).Error(0)
+}
+
+func (p *mockProjector) Unproject(ctx context.Context, binding *servicebindingv1beta1.ServiceBinding, workload runtime.Object) error {
+	*p.i = *p.i + 1
+	return p.m.MethodCalled("Projector.Unproject", *p.i, ctx, binding, workload).Error(0)
+}
+
+func makeHooks() (lifecycle.ServiceBindingHooks, *mock.Mock) {
+	m := &mock.Mock{}
+	i := pointer.Int(0)
+	hooks := lifecycle.ServiceBindingHooks{
+		ResolverFactory: func(c client.Client) resolver.Resolver {
+			return resolver.New(c)
+		},
+		ProjectorFactory: func(ms projector.MappingSource) projector.ServiceBindingProjector {
+			return &mockProjector{m: m, i: i}
+		},
+		ServiceBindingPreProjection: func(ctx context.Context, binding *servicebindingv1beta1.ServiceBinding) error {
+			*i = *i + 1
+			return m.MethodCalled("ServiceBindingPreProjection", *i, ctx, binding).Error(0)
+		},
+		ServiceBindingPostProjection: func(ctx context.Context, binding *servicebindingv1beta1.ServiceBinding) error {
+			*i = *i + 1
+			return m.MethodCalled("ServiceBindingPostProjection", *i, ctx, binding).Error(0)
+		},
+		WorkloadPreProjection: func(ctx context.Context, workload runtime.Object) error {
+			*i = *i + 1
+			return m.MethodCalled("WorkloadPreProjection", *i, ctx, workload).Error(0)
+		},
+		WorkloadPostProjection: func(ctx context.Context, workload runtime.Object) error {
+			*i = *i + 1
+			return m.MethodCalled("WorkloadPostProjection", *i, ctx, workload).Error(0)
+		},
+	}
+
+	return hooks, m
+}


### PR DESCRIPTION
The hooks allow defining a custom Resolver or Projector as well as interacting with the ServiceBinding and workload resources before before and after projection.

Defining no hooks is equivalent to the current RI behavior.

The controller operates on a single ServiceBinding and zero-to-many workloads in a single request, while the webhook operates on a single workload with zero-to-many ServiceBindings. Because of this mismatch, we split out interactions with the ServiceBinding and workload resources into independent hooks.

Depends on #335