### PR TITLE
Test on Kubernetes 1.38

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -225,6 +225,7 @@ jobs:
           - kubernetes-version: v1.35
           - kubernetes-version: v1.36
           - kubernetes-version: v1.37
+          - kubernetes-version: v1.38
     steps:
       - uses: actions/checkout@v7
       - parallel:


### PR DESCRIPTION
While currently alpha, this will track it's development and eventual release.